### PR TITLE
fix: encode response from getCodeContext to properly escape special c…

### DIFF
--- a/src/utils/codeContext.ts
+++ b/src/utils/codeContext.ts
@@ -13,5 +13,5 @@ export const getCodeContext = (
   const lines = source.split("\n");
   const start = Math.max(lineNumber - contextLines - 1, 0);
   const end = Math.min(lineNumber + contextLines, lines.length);
-  return lines.slice(start, end).join("\n");
+  return JSON.stringify(lines.slice(start, end).join("\n"));
 };


### PR DESCRIPTION
…haracters